### PR TITLE
Changed to strategy build of CI

### DIFF
--- a/.github/workflows/ci-casper-rust-contract.yml
+++ b/.github/workflows/ci-casper-rust-contract.yml
@@ -13,9 +13,10 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-18.04
-
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -9,7 +9,10 @@ on:
 
 jobs:
   nightly-make-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Bumping to run on 20.04 and 22.04.